### PR TITLE
Switch to PEP 518 to fix build dependencies

### DIFF
--- a/PythonAPI/pyproject.toml
+++ b/PythonAPI/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = [
+    "setuptools>=18.0",
+    "cython>=0.27.3",
+    "numpy>=1.0",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pycocotools"
+version = "2.0"
+requires-python = ">=3.7"
+dependencies = [
+    "numpy>=1.0",
+]
+
+[tool.setuptools]
+packages = ["pycocotools"]
+package-dir = {"pycocotools" = "pycocotools"}

--- a/PythonAPI/setup.py
+++ b/PythonAPI/setup.py
@@ -1,26 +1,17 @@
-from setuptools import setup, Extension
+# setup.py (minimal shim for dynamic configuration)
+from setuptools import setup
 import numpy as np
 
-# To compile and install locally run "python setup.py build_ext --inplace"
-# To install library to Python site-packages run "python setup.py build_ext install"
+def build_with_numpy():
+    from setuptools import Extension
+    ext_modules = [
+        Extension(
+            'pycocotools._mask',
+            sources=['../common/maskApi.c', 'pycocotools/_mask.pyx'],
+            include_dirs=[np.get_include(), '../common'],
+            extra_compile_args=['-Wno-cpp', '-Wno-unused-function', '-std=c99'],
+        )
+    ]
+    return {"ext_modules": ext_modules}
 
-ext_modules = [
-    Extension(
-        'pycocotools._mask',
-        sources=['../common/maskApi.c', 'pycocotools/_mask.pyx'],
-        include_dirs = [np.get_include(), '../common'],
-        extra_compile_args=['-Wno-cpp', '-Wno-unused-function', '-std=c99'],
-    )
-]
-
-setup(
-    name='pycocotools',
-    packages=['pycocotools'],
-    package_dir = {'pycocotools': 'pycocotools'},
-    install_requires=[
-        'setuptools>=18.0',
-        'cython>=0.27.3'
-    ],
-    version='2.0',
-    ext_modules= ext_modules
-)
+setup(**build_with_numpy())


### PR DESCRIPTION
Specifying numpy in `setup_requires` field does not serve its purpose as the setup.py script fails because of an ImportError  (because of numpy). It's a well-known [chicken-and-egg problem](https://peps.python.org/pep-0518/#:~:text=But%20when%20a,run%20the%20file.) that is solved by switching to a pyproject.toml defined project. 
I propose to keep a minimal setup.py to build the C extension and dynamically retrieve `get_include()`. 